### PR TITLE
Bug #22 - Make "Add" button put color in palette on 1st click:

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       <h2>Key Color<span id="hexText"></span></h2>
       <h2>
         Palette
-        <button class="btn addHistoryBtnJs">Add</button>
+        <button type="button" class="btn addHistoryBtnJs">Add</button>
       </h2>
     </div>
     <fieldset>
@@ -211,7 +211,7 @@
         <h2>Secondary Color<span id="secHexText"></span></h2>
         <h2>
           Palette
-          <button class="btn addHistoryBtnJs">Add</button>
+          <button type="button" class="btn addHistoryBtnJs">Add</button>
         </h2>
       </div>
       <fieldset>

--- a/js/main.js
+++ b/js/main.js
@@ -15,7 +15,6 @@ colorForm.addEventListener('submit', function(event) {
   event.preventDefault();
   colorBtn.blur();
   const color = this.elements.colorInput.value;
-  if (sessionHistory.historyList.includes(color)) return;
   generateColors(color);
   if (sessionHistory.currentPage === 'colorWheel') {
     updateUI('complementaryTab');

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -65,7 +65,8 @@ function updateHistory(event) {
 };
 
 function setSectionColor(target) {
-  const color = target.parentElement.parentElement.querySelector('span').textContent;
+  const color = target.parentElement.parentElement.parentElement
+    .querySelector('input').value;
   if (color && color!="") sessionHistory.addHistory(color);
 }
 

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -66,7 +66,7 @@ function updateHistory(event) {
 
 function setSectionColor(target) {
   const color = target.parentElement.parentElement.querySelector('span').textContent;
-  if (color) sessionHistory.addHistory(color);
+  if (color && color!="") sessionHistory.addHistory(color);
 }
 
 // Contructor function for color history functionality


### PR DESCRIPTION
Hello Jacob and an folks reviewing this code,

This change is more a "button behavioral" change than technical. The rationale is that the "Add" button should add colors to the bar only after the colors are already defined, and the "Palette" button should define the primary or secondary color based on the selected color.

Currently, the "Add" button triggers some code execution even if there is no previously selected color, exhibiting the undesired behavior listed on this bug.

One solution is to remove this button as suggested in my previous comment<https://github.com/jb-tlm/color-charter/issues/22#issuecomment-1639080919> because case #13 added the ability to click on any color to add it to the Color Bar.

The proposed solution is to allow the "Add" button to work only after selecting a color with the "Palette" button.

Please, let me know if you prefer to remove the button or otherwise by accepting this PR will *conditionally* enable the button.
